### PR TITLE
Fix 'weight' -> 'value' in Knapsack solution 2

### DIFF
--- a/chapter07.tex
+++ b/chapter07.tex
@@ -683,7 +683,7 @@ using the following sequence:
 denote the smallest possible total weight
 when a subset of objects
 $1 \ldots k$ is selected such
-that the total weight is $u$.
+that the total value is $u$.
 The solution to the problem is the
 largest value $u$
 for which  $0 \le u \le s$ and $f(n,u) \le x$


### PR DESCRIPTION
In solution 2, the variable $u$ represents a value, but it is described as the 'total weight'. I presume it is a left-over from copy-pasting solution 1.