### PR TITLE
Chapter 13: Constant Time Lookup of Next Node

### DIFF
--- a/chapter04.tex
+++ b/chapter04.tex
@@ -605,10 +605,10 @@ A \key{priority queue}
 maintains a set of elements.
 The supported operations are insertion and,
 depending on the type of the queue,
-retrieval and removal of
+lookup and removal of
 either the minimum or maximum element.
 Insertion and removal take $O(\log n)$ time,
-and retrieval takes $O(1)$ time.
+and lookup takes $O(1)$ time.
 
 While an ordered set efficiently supports
 all the operations of a priority queue,

--- a/chapter13.tex
+++ b/chapter13.tex
@@ -553,7 +553,7 @@ minimum distance node that has not been processed.
 An appropriate data structure for this is a priority queue
 that contains the nodes ordered by their distances.
 Using a priority queue, the next node to be processed
-can be retrieved in constant time.
+can be looked up in constant and removed in logarithmic time.
 
 In the following code, the priority queue
 \texttt{q} contains pairs of the form $(-d,x)$,

--- a/chapter13.tex
+++ b/chapter13.tex
@@ -553,7 +553,7 @@ minimum distance node that has not been processed.
 An appropriate data structure for this is a priority queue
 that contains the nodes ordered by their distances.
 Using a priority queue, the next node to be processed
-can be retrieved in logarithmic time.
+can be retrieved in constant time.
 
 In the following code, the priority queue
 \texttt{q} contains pairs of the form $(-d,x)$,


### PR DESCRIPTION
Isn't the lookup time of the next node constant instead of logarithmic?
Current version:
> Using a priority queue, the next node to be processed can be retrieved in logarithmic time.

Referring to cppreference.com:
> A priority queue [...] provides *constant time lookup* of the largest (by default) element, at the expense of logarithmic insertion and extraction.

Referring to Page 43:
> A priority queue maintains a set of elements [...] and retrieval takes O(1) time.