### PR TITLE
Correct threshold in the scaling method

### DIFF
--- a/chapter20.tex
+++ b/chapter20.tex
@@ -446,7 +446,7 @@ The \key{scaling algorithm} \cite{ahu91} uses depth-first
 search to find paths where each edge weight is
 at least a threshold value.
 Initially, the threshold value is
-some large number, for example the sum of all
+some large number, for example the maximum of all
 edge weights of the graph.
 Always when a path cannot be found,
 the threshold value is divided by 2.


### PR DESCRIPTION
It doesn’t make sense to make threshold bigger than the maximal weight, as it’s going to include all the edges anyways.

The complexity, m^2 \log c, also seems wrong to me (picking c=1 doesn’t seem like the best idea), but it isn’t immediately obvious what’s the right estimate here.